### PR TITLE
Add `--fix-missing` flag to `apt-get update`

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -6,7 +6,7 @@ ENV TZ=${TZ}
 
 # include manual pages and documentation
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update &&\
+RUN apt-get update --fix-missing &&\
   yes | unminimize
 
 # install GCC-related packages

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -6,7 +6,7 @@ ENV TZ=${TZ}
 
 # include manual pages and documentation
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update &&\
+RUN apt-get update --fix-missing &&\
   yes | unminimize
 
 # copy new sources.list


### PR DESCRIPTION
I believe this fixes Ed post [#25](https://edstem.org/us/courses/45994/discussion/3406595). I didn't get the exact same error as they did, but my build was also failing on these packages. Adding this flag fixed it on my end, but it seems to make builds take longer :(